### PR TITLE
chore(versioning): Drop leading v from version number in file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,9 @@ jobs:
         run: |
           FILE="org-tag-cloud.el"
           NEW_VERSION="${{ steps.dry_tag.outputs.new_tag }}"
-          echo "Updating version to $NEW_VERSION in $FILE"
-          sed -i "s/^;; Version: .*/;; Version: $NEW_VERSION/" "$FILE"
+          VERSION=$(echo "$NEW_VERSION" | tr -d 'v')
+          echo "Updating version to $VERSION in $FILE"
+          sed -i "s/^;; Version: .*/;; Version: $VERSION/" "$FILE"
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
           git add "$FILE"


### PR DESCRIPTION
This commit drops the leading "v" from our generated version in the actual emacs lisp file.  It remains in our tag.