### PR TITLE
feat(sorting-cleanup): Cleanup code, allow sorting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,18 @@
+NAME = org-tag-cloud
 EMACS ?= emacs
 
-org-tag-cloud.elc: org-tag-cloud.el
-	$(EMACS) --batch -L . -l org-tag-cloud.el -eval '(byte-compile-file "org-tag-cloud.el")'
+# Run all tests by default.
+MATCH ?=
+
+.PHONY: test
+
+test:
+	cd test/ && $(EMACS) --batch -L . -L .. -l ${NAME}-test.el -eval '(ert-run-tests-batch-and-exit "$(MATCH)")'
 
 clean:
 	find . -name '*.elc' -delete
 
-bytecompile: org-tag-cloud.elc
+${NAME}.elc: ${NAME}.el
+	$(EMACS) --batch -L . -l ${NAME}.el -eval '(byte-compile-file "org-tag-cloud.el")'
+
+bytecompile: ${NAME}.elc

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ There are three main functions of interest:
 * `org-tag-cloud-update` - Update an existing cloud.
 * `org-tag-cloud-save-hook` - Something to add to save-hook to automate updates when files are saved.
 
-The only configuration value is `org-tag-cloud-name-first`, when this is non-nil the tag-name is listed in the first column, followed by the frequency as the second column.  When nil the ordering is reversed.
+The main configuration value is `org-tag-cloud-name-first`, when this is non-nil the tag-name is listed in the first column, followed by the frequency as the second column.  When nil the ordering is reversed.
+
+Sorting defaults to showing the table with the highest frequencies first, but you might prefer to show by alphabetical tag.  See example.org, or the package for how to set that.
 
 
 
@@ -68,5 +70,5 @@ you have tagged with the value `foo`.
 
 ## Limitations
 
-* There can only be one tag cloud in a specific document, because the name is fixed.
+* There can only be one tag cloud in a specific document.
 * The tag cloud refers only to the current file, you cannot make a cloud of tags used across multiple `org-mode' files.

--- a/example.org
+++ b/example.org
@@ -11,21 +11,20 @@ This document holds an example of a tag-cloud.
 
 * Tags                                                             :noexport:
 
-#+BEGIN: tagcloud
-| Frequency | Tag          |
-|-----------+--------------|
-|         2 | [[tag:household][household]]    |
-|         1 | [[tag:github][github]]       |
-|         1 | [[tag:org][org]]          |
-|         1 | [[tag:windows][windows]]      |
-|         1 | [[tag:laundry][laundry]]      |
-|         1 | [[tag:noexport][noexport]]     |
-|         1 | [[tag:introduction][introduction]] |
-
+#+BEGIN: tagcloud :sort alpha
+| Tag          | Frequency |
+|--------------+-----------|
+| [[tag:github][github]]       |         1 |
+| [[tag:household][household]]    |         2 |
+| [[tag:introduction][introduction]] |         1 |
+| [[tag:laundry][laundry]]      |         1 |
+| [[tag:noexport][noexport]]     |         1 |
+| [[tag:org][org]]          |         1 |
+| [[tag:windows][windows]]      |         1 |
 #+END:
 
 * Tasks
-This section contains some tasts, each with tags.
+ This section contains some tasts, each with tags.
 ** DONE Run some laundry                                 :household:laundry:
 CLOSED: [2022-02-07 Mon 18:46]
 - Clean clothes are nice.

--- a/org-tag-cloud.el
+++ b/org-tag-cloud.el
@@ -59,16 +59,39 @@
 ;;  :hook
 ;;    (before-save-hook . org-tag-cloud-save-hook))
 
+;;; Configuration:
+
+;; Sorting may be set to sort by the tag name, or the frequency
+;; count - the latter is the default.  Specify the value in either
+;; the configuration value `org-tag-cloud-sort-method' or inside
+;; the block itself, for example:
+;;
+;;     #+BEGIN: tagcloud :sort alpha
+;; or
+;;     #+BEGIN: tagcloud :sort frequency
+;;
+
 ;;; Limitations:
 
-;; There can only be one tag cloud in a specific document, because
-;; the name is fixed.
+;; Two main limitations are related:
 ;;
-;; The tag cloud refers only to the current file, you cannot make
-;; a cloud of tags used across multiple `org-mode' files.
+;;  1. There can only be one tag cloud in a specific document.
+;;
+;;  2. The tag cloud refers only to the current file, you cannot
+;;     make a cloud of tags used across multiple `org-mode' files.
 ;;
 
 ;;; Configuration:
+
+(defvar org-tag-cloud-block-name "tagcloud"
+  "Name of the dynamic block used for tag clouds.")
+
+(defvar org-tag-cloud-sort-method 'frequency
+  "Method to sort tags in the tag cloud.
+
+Possible values:
+- \='frequency : Sort by frequency, descending (default)
+- \='alpha     : Sort alphabetically by tag name.")
 
 (defvar org-tag-cloud-name-first t
   "Specify the column order on the generated table.
@@ -100,15 +123,18 @@ populated via a call to `org-tag-cloud-update'."
 This relies upon the fact that the tag-cloud has a static
 name, which can be used by `org-find-dblock'."
   (interactive "*")
-  (if (org-find-dblock "tagcloud")
-      (let ((m (point-marker))
-            (ws (window-start)))
-        (org-with-wide-buffer
-         (save-excursion
-           (org-update-dblock)))
-        (set-window-start nil ws)
-        (goto-char m)
-        (set-marker m nil))))
+  (when (org-find-dblock org-tag-cloud-block-name)
+    (let ((pos (copy-marker (point)))
+          (win (selected-window))
+          (start (window-start)))
+      (unwind-protect
+          (org-with-wide-buffer
+           (org-update-dblock))
+        ;; Restore everything explicitly
+        (when (marker-buffer pos)
+          (set-window-start win start)
+          (goto-char pos)
+          (set-marker pos nil))))))
 
 ;; tag:-link support
 
@@ -126,43 +152,54 @@ name, which can be used by `org-find-dblock'."
 
 ;;; dblock glue
 
-(defun org-dblock-write:tagcloud (_params)
+(defun org-dblock-write:tagcloud (params)
   "Called when a block of name tagcloud is to be processed.
 
 This is the magic that updates the tag-cloud, the variable
-`org-tag-cloud-name-first' is used to determine the column-order."
-  (let ((tags (org-tag-cloud--collect)))
-    (if org-tag-cloud-name-first
-        (insert "| Tag | Frequency |\n|-\n")
-      (insert "| Frequency | Tag |\n|-\n"))
-    (dolist (row tags)
-      (if org-tag-cloud-name-first
-          (insert (format "| %s | %d |\n"
-                          (cadr row)
-                      (car row)))
-        (insert (format "| %d | %s |\n"
-                        (car row)
-                        (cadr row)))))
-    ;; fixup formatting once generated
-    (org-table-align)))
+`org-tag-cloud-name-first' is used to determine the column-order.
 
+PARAMS is a plist of dynamic block parameters.  Recognized keys:
+
+  :sort   - \='frequency or \='alpha (default \='frequency)
+  :name   - name of the block (optional, for multiple clouds)"
+  (let* ((sort-method (or (plist-get params :sort) 'frequency))
+         (name-first org-tag-cloud-name-first)
+         (tags (let ((org-tag-cloud-sort-method sort-method))
+                 (org-tag-cloud--collect)))
+         (header (if name-first "| Tag | Frequency |\n|-\n"
+                   "| Frequency | Tag |\n|-\n"))
+         (rows
+          (mapconcat
+           (lambda (row)
+             (pcase-let ((`(,count ,tag) row))
+               (if name-first
+                   (format "| %s | %d |" tag count)
+                 (format "| %d | %s |" count tag))))
+           tags
+           "\n")))  ;; join with newline, no trailing newline
+    (insert header rows)
+    (org-table-align)))
 
 (defun org-tag-cloud--collect ()
   "Find the distinct tags, and their counts, within the current file."
-  (let (tags)
+  (let ((counts (make-hash-table :test #'equal)))
+    ;; collect tags
     (save-excursion
       (goto-char (point-min))
       (while (re-search-forward org-complex-heading-regexp nil t)
         (dolist (tag (org-get-tags))
           (unless (string-empty-p tag)
-            (push tag tags)))))
-    (cl-loop for tag in (cl-remove-duplicates tags :test #'string=)
-             collect
-             (list (cl-count tag tags :test #'string=)
-                   (format "[[tag:%s][%s]]" tag tag))
-             into result
-             finally return (cl-sort result #'> :key #'car))))
-
+            (cl-incf (gethash tag counts 0))))))
+    ;; convert to list of (count display)
+    (let ((result
+           (cl-loop for tag being the hash-keys of counts
+                    using (hash-values count)
+                    collect (list count (format "[[tag:%s][%s]]" tag tag)))))
+      ;; sort based on `org-tag-cloud-sort-method`
+      (cl-case org-tag-cloud-sort-method
+        (frequency (cl-sort result #'> :key #'car))
+        (alpha (cl-sort result #'string< :key (lambda (x) (cadr x))))
+        (t (error "Invalid `org-tag-cloud-sort-method`: %S" org-tag-cloud-sort-method))))))
 
 ;; Utility
 (defun org-tag-cloud-save-hook ()
@@ -170,7 +207,7 @@ This is the magic that updates the tag-cloud, the variable
 
 This will silently and safely do nothing if there is no `dblock' with the
 name \='tagcloud\=' within the document."
-  (if (derived-mode-p 'org-mode)
+  (when (derived-mode-p 'org-mode)
     (org-tag-cloud-update)))
 
 

--- a/test/org-tag-cloud-test.el
+++ b/test/org-tag-cloud-test.el
@@ -1,0 +1,64 @@
+(require 'ert)
+(require 'org)
+(require 'org-tag-cloud)
+
+(ert-deftest org-tag-cloud-test-frequency-sorting ()
+  "Test that tags are sorted by frequency."
+  (with-temp-buffer
+    (org-mode)
+    ;; insert headings with tags
+    (insert "* TODO Task1 :foo:bar:\n")
+    (insert "* TODO Task2 :foo:baz:\n")
+    (insert "* TODO Task3 :foo:bar:\n")
+    ;; set sorting to frequency
+    (let ((org-tag-cloud-sort-method 'frequency))
+      (let ((tags (org-tag-cloud--collect)))
+        ;; Expect top tag to be "foo" (3 occurrences)
+        (should (string-match-p "foo" (cadr (car tags))))
+        ;; Expect descending counts
+        (let ((counts (mapcar #'car tags)))
+          (should (cl-every (lambda (x y) (>= x y))
+                            counts (cdr counts))))))))
+
+(ert-deftest org-tag-cloud-test-alpha-sorting ()
+  "Test that tags are sorted alphabetically."
+  (with-temp-buffer
+    (org-mode)
+    ;; insert headings with tags
+    (insert "* TODO Task1 :zeta:alpha:\n")
+    (insert "* TODO Task2 :beta:alpha:\n")
+    (insert "* TODO Task3 :gamma:beta:\n")
+    ;; set sorting to alpha
+    (let ((org-tag-cloud-sort-method 'alpha))
+      (let ((tags (org-tag-cloud--collect)))
+        (let ((names (mapcar (lambda (x) (cadr x)) tags)))
+          ;; names should be sorted alphabetically
+          (should (equal names (sort (copy-sequence names) #'string<))))))))
+
+
+(ert-deftest org-tag-cloud-test-table-generation ()
+  "Check that the tag cloud table is created correctly."
+  (with-temp-buffer
+    (org-mode)
+    (insert "* TODO Task1 :foo:bar:\n* TODO Task2 :foo:\n")
+    ;; Insert a dummy block
+    (insert "#+BEGIN: tagcloud\n#+END:\n")
+    ;; Move to BEGIN line
+    (goto-char (point-min))
+    (search-forward "#+BEGIN: tagcloud")
+    ;; Force table generation
+    (org-dblock-write:tagcloud nil)
+    ;; The table should now contain a row for "foo"
+    (goto-char (point-min))
+    (should (re-search-forward "foo.*2" nil t))
+    ;; And for "bar"
+    (goto-char (point-min))
+    (should (re-search-forward "bar.*1" nil t))))
+
+;; ----------------------------------------------------------------------
+;; Run tests
+;; ----------------------------------------------------------------------
+
+(ert-run-tests-interactively t)
+
+;;; org-people-test.el ends here


### PR DESCRIPTION
This pull-request cleans up the code to make it nicer - speeding up the collection of tag-data.

We introduced the ability to add :sort parameter to the table to specify if we sort by tag or frequency.  There's also a global setting.

Finally we added a simple set of test-cases and updated the Makefile to be more portable.