### PR TITLE
chore(documentation): Fixed a broken tag-link in the docs

### DIFF
--- a/org-tag-cloud.el
+++ b/org-tag-cloud.el
@@ -32,7 +32,7 @@
 ;; The cloud is rendered as an `org-mode' table and can be updated
 ;; automatically when the file is saved.  The rendered table will
 ;; make each tag clickable via a newly-installed protocol handler
-;; for links of the form [[tag::foo].
+;; for links of the form [[tag::foo]].
 ;;
 ;; There are three main functions of interest:
 ;;


### PR DESCRIPTION
This pull-request just adds the missing "]" character to a sample link within our package documentation.