### PR TITLE
chore(security): Pin github actions we use, via SHA1

### DIFF
--- a/.github/workflows/melpazoid.yml
+++ b/.github/workflows/melpazoid.yml
@@ -10,9 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6
       with: { python-version: '3.10' }
     - name: Install
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
 
@@ -46,7 +46,7 @@ jobs:
 
       # 4️⃣ Create GitHub release pointing to the correct tag
       - name: Create GitHub release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd #v1
         with:
           tag: ${{ steps.real_tag.outputs.new_tag }}
           name: Release ${{ steps.real_tag.outputs.new_tag }}


### PR DESCRIPTION
I think this is perhaps overly paranoid, but supply-change attacks aren't impossible.